### PR TITLE
Update project homepage a few places.

### DIFF
--- a/README
+++ b/README
@@ -33,7 +33,7 @@ portable, fast, and precisely documented.
     - precisely documented: lci uses Doxygen to generate literate code
           documentation, browsable here.
 
-This project's homepage is at http://icanhaslolcode.org.  For help, visit
+This project's homepage is at http://lolcode.org.  For help, visit
 http://groups.google.com/group/lci-general.  To report a bug, go to
 http://github.com/justinmeza/lci/issues.
 

--- a/main.c
+++ b/main.c
@@ -25,7 +25,7 @@
  *   (justin.meza@gmail.com).
  *
  *   - For more information, check this project's webpage at
- *   http://icanhaslolcode.org .
+ *   http://lolcode.org .
  *
  * \section about About
  *


### PR DESCRIPTION
There were two links to http://icanhaslolcode.org/ , which is now a parked
domain.  Now those appropriately go to http://lolcode.org/ .
