### PR TITLE
Defensive strategy that prevents a range of possible null pointer errors...

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -1368,6 +1368,7 @@ int acceptToken(Token ***tokenp,
                 TokenType token)
 {
 	Token **tokens = *tokenp;
+	if (!(*tokens)) return 0;
 	if ((*tokens)->type != token) return 0;
 	tokens++;
 	*tokenp = tokens;
@@ -1427,7 +1428,11 @@ int nextToken(Token ***tokenp,
 void parser_error(ErrorType type,
                   Token **tokens)
 {
-	error(type, (*tokens)->fname, (*tokens)->line, (*tokens)->image);
+	if(!(*tokens)) {
+		error(type, "Unhandled string detected", 1, "undefined");
+	} else {
+		error(type, (*tokens)->fname, (*tokens)->line, (*tokens)->image);
+	}
 }
 
 /**


### PR DESCRIPTION
... from causing crashes

This allows a graceful failure in the event of several identified invalid inputs. Below is an example of a file that causes the existing parser to segfault.

00000000  48 41 49 00 31 2e 33 0a  09 49 4d 20 49 4e 20 59  |HAI.1.3..IM IN Y|
00000010  52 20 6c 6f 6f 70 20 55  50 50 49 4e 20 59 52 20  |R loop UPPIN YR |
00000020  76 61 72 20 54 49 4c 20  42 4f 54 48 20 53 41 45  |var TIL BOTH SAE|
00000030  4d 20 76 61 72 20 41 4e  20 31 30 0a 09 09 56 49  |M var AN 10...VI|
00000040  53 49 42 4c 45 20 76 61  72 0a 09 49 4d 20 4f 55  |SIBLE var..IM OU|
00000050  54 54 41 20 59 52 20 6c  6f 6f 70 0a 4b 54 48 58  |TTA YR loop.KTHX|
00000060  42 59 45 0a                                       |BYE.|
00000064
