### PR TITLE
interpolate system commands

### DIFF
--- a/interpreter.c
+++ b/interpreter.c
@@ -1920,7 +1920,7 @@ ValueObject *interpretSystemCommandExprNode(ExprNode *node,
 	val = interpretExprNode(expr->cmd, scope);
         if (!val) return NULL;
 
-	cmd = getString(val);
+	cmd = getString(castStringExplicit(val, scope));
 
 
 	/* Open the command for reading */


### PR DESCRIPTION
It may be the case that operands to `I DUZ` should not undergo
interpolation, but I'm unable to perceive the rationale. In any case,
the fix is simply to pass the argument through `castStringExplicit()`,
which is unlikely to break any existing code.

I considered adding a test, only to discover that `I DUZ` itself is not
presently being tested. I suppose this is probably to do with its being
a future feature, or else that ensuring its proper functionality across
platforms wouldn't be trivial.

In the latter case, the `echo` command is likely to be available in the
vast majority of environments, and is probably the best candidate for
testing this facet of the language.