### PR TITLE
Added sleep(3) from unistd.h as SLEPE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cmake_install.cmake
 install_manifest.txt
 CTestTestfile.cmake
 tags
+.vscode/

--- a/main.c
+++ b/main.c
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
 	FILE *file = NULL;
 	int ch;
 
-	char *revision = "v0.11.2";
+	char *revision = "v0.11.3";
 	program_name = argv[0];
 
 	while ((ch = getopt_long(argc, argv, shortopt, longopt, NULL)) != -1) {


### PR DESCRIPTION
While adding a LOLCODE implementation to my https://github.com/andysturrock/CoffeeMug repo I realised I needed a way to sleep LOLCODE for x seconds.  This PR adds the sleep(3) call from unistd.h.

I bumped the version from v0.11.2 to v0.11.3 - I assume that was the right thing to do but please feel free to dump that change if not.