### PR TITLE
chore(deps): bump cmake from 3.31 to 4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 4.1)
 project(lci)
 
 ENABLE_TESTING()
@@ -10,18 +10,18 @@ MARK_AS_ADVANCED(PERFORM_MEM_TESTS)
 IF(${PERFORM_MEM_TESTS})
   find_program(VALGRIND valgrind)
   IF(NOT VALGRIND)
-    message(FATAL_ERROR 
+    message(FATAL_ERROR
 "
   Error: You've enabled memory testing but we can't find valgrind
-  Try one of the following: 
-  1: Make sure valgrind is in your PATH 
-  2: Install valgrind if you already haven't 
+  Try one of the following:
+  1: Make sure valgrind is in your PATH
+  2: Install valgrind if you already haven't
   3: Disable memory testing
 ")
   ENDIF(NOT VALGRIND)
 ENDIF(${PERFORM_MEM_TESTS})
 
-SET(HDRS 
+SET(HDRS
   interpreter.h
   lexer.h
   parser.h
@@ -39,7 +39,7 @@ SET(SRCS
   unicode.c
   error.c
 )
-  
+
 add_executable(lci ${SRCS} ${HDRS})
 target_link_libraries(lci m)
 add_subdirectory(test)
@@ -56,6 +56,6 @@ if(DOXYGEN_FOUND)
   COMMENT "Generating API documentation with Doxygen" VERBATIM
   )
 else(DOXYGEN_FOUND)
-  message(WARNING 
+  message(WARNING
     "Couldn't find doxygen. You won't be able to generate documentation now")
 endif(DOXYGEN_FOUND)


### PR DESCRIPTION
Bumping `cmake_minimum_required` from `3.31` to `4.1` to fix the following error when running with latest `cmake` (`4.1.1` at the moment):

```text
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
-- Configuring incomplete, errors occurred!
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```